### PR TITLE
fix: corrigir erro de cvar incorreta e valor padrão

### DIFF
--- a/lua/zen_loadout/client/cl_main.lua
+++ b/lua/zen_loadout/client/cl_main.lua
@@ -1,6 +1,6 @@
-CreateClientConVar("ttt_zen_loadout_primary_choice", FCVAR_USERINFO, "random", true)
-CreateClientConVar("ttt_zen_loadout_secondary_choice", FCVAR_USERINFO, "random", true)
-CreateClientConVar("ttt_zen_loadout_equipment_choice", FCVAR_USERINFO, "random", true)
+CreateClientConVar("ttt_zen_loadout_primary_choice", "random", FCVAR_USERINFO, true)
+CreateClientConVar("ttt_zen_loadout_secondary_choice", "random", FCVAR_USERINFO, true)
+CreateClientConVar("ttt_zen_loadout_equipment_choice", "random", FCVAR_USERINFO, true)
 
 local function RequestWeapons()
 

--- a/lua/zen_loadout/server/sv_zen_loadout.lua
+++ b/lua/zen_loadout/server/sv_zen_loadout.lua
@@ -78,6 +78,7 @@ function plymeta:GiveLoadout(ply_prefs, inv_weps)
         end
         
         local wep_obj = weapons.Get(wep_class)
+        if not wep_obj then continue end
 
         self:Give(wep_class)
 


### PR DESCRIPTION
- adicionar validação para objeto de arma escolhida na cvar para impedir que um valor que não corresponde a uma arma do servidor cause erro ao dar a arma ao jogador